### PR TITLE
Use the new delete single avail date endpoint

### DIFF
--- a/client/src/components/DateRangeDisplayer.js
+++ b/client/src/components/DateRangeDisplayer.js
@@ -71,7 +71,7 @@ class DateRangeDisplayer extends Component {
 
   deleteAvailability(date) {
     axios
-      .delete(this.url, { data: [date] })
+      .delete(`${this.url}/${date}`)
       .then(response => {
         alert(`${date.slice(0, 10)} successfully deleted.`);
         const { datesArray } = this.state;


### PR DESCRIPTION
The issue with cors was a red herring. AWS api gateway doesnt seem to pass the body of delete requests so I created a new end point to delete a single date as a work arround. We get the cors error as the function bombs before the cors header is set.